### PR TITLE
remove incorrect version check from use_ok calls

### DIFF
--- a/t/00_jip_spy_event.t
+++ b/t/00_jip_spy_event.t
@@ -8,7 +8,7 @@ use Test::More;
 use English qw(-no_match_vars);
 
 BEGIN {
-    use_ok 'JIP::Spy::Event', 'v0.0.4';
+    use_ok 'JIP::Spy::Event';
 }
 
 subtest 'Require some module' => sub {

--- a/t/01_jip_spy_events.t
+++ b/t/01_jip_spy_events.t
@@ -8,7 +8,7 @@ use Test::More;
 use English qw(-no_match_vars);
 
 BEGIN {
-    use_ok 'JIP::Spy::Events', 'v0.0.4';
+    use_ok 'JIP::Spy::Events';
 }
 
 subtest 'Require some module' => sub {


### PR DESCRIPTION
The arguments to use_ok are passed along to the module's import method. JIP::Spy::Event has no import method, so these arguments were just being ignored. use_ok doesn't provide a way to do a version check. The module being checked is the module in this dist, so the version check would have provided little value.

Future versions of perl are intending to make passing arguments to an undefined import method an error.